### PR TITLE
dev env: add upper version constraint for isort & importlib-metadata to keep compatibility with python3.5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,11 +15,13 @@ pytest = "*"
 pytest-cov = "*"
 pytest-timeout = "*"
 
+# python3.5 compatibility
+# https://github.com/python/importlib_metadata/commit/107f9029fd5807c6579b881db19e11a0488f0675
+# fix pluggy/manager.py (v0.13.1) on python<3.8: import importlib_metadata => ModuleNotFoundError
+importlib-metadata = {version = "<3", markers="python_version < '3.8'"}
+isort = "<5"
 # workaround https://github.com/pytest-dev/pytest/issues/3953
 pathlib2 = {version = "*", markers="python_version < '3.6'"}
-# fix pluggy/manager.py (v0.13.1): import importlib_metadata => ModuleNotFoundError
-importlib_metadata = {version = "*", markers="python_version < '3.8'"}
-# zipp v2.0.0 dropped support for python3.5
 # https://github.com/jaraco/zipp/commit/05a3c52b4d41690e0471a2e283cffb500dc0329a
 zipp = "<2"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b1ab9031e0f908588df278ac271280c98464e94a32fbbc34632ba5b22659cd24"
+            "sha256": "22cf82d03532bc962e00557bfaec45e6a3ec033bbada1f6c94fed2a6a3ed8507"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
https://github.com/fphammerle/acpi-backlight/commit/cf4ab276b64ba7a2fe0667642410e1762c1e4f16
https://github.com/fphammerle/ical2vdir/commit/1bb7b57d8712f09c1c5ccfd91d6a37312f94e249